### PR TITLE
normalizing filepath separator for every OS in the generate schema.sql

### DIFF
--- a/macros/schema_generation.sql
+++ b/macros/schema_generation.sql
@@ -2,7 +2,8 @@
     {%- set default_schema = target.schema -%} 
     {%- if custom_schema_name is none -%}
         {%- set model_path_str = node.path | string -%}
-        {%- set folder_name = model_path_str.split('/')[-2] -%}
+        {%- set normalized_path = model_path_str.replace('\\', '/') -%}
+        {%- set folder_name = normalized_path.split('/')[-2] -%}
         {{ folder_name }}
     {%- else -%}
         {{ default_schema }}_{{ custom_schema_name | trim }}


### PR DESCRIPTION
Dans la macro "generate schema", on recpuère le nom de dossier à partir du pwd. Cependant, le séparateur "/" n'est pas détecté sur Windows (en tout cas sur ma version). 
L'idée est que ça fonctionne à la fois pour les OS UNIX qui ont pour séparateur "/" et Windows "\\". 